### PR TITLE
Add web-config file for HTTPS setup

### DIFF
--- a/create_web_config.sh
+++ b/create_web_config.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# See https://docs.cloudfoundry.org/devguide/deploy-apps/instance-identity.html
+# for information on Cloud Foundry Instance Identity Credentials.
 {
     echo "---"
     echo "tls_server_config:"

--- a/create_web_config.sh
+++ b/create_web_config.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+{
+    echo "---"
+    echo "tls_server_config:"
+    echo "  cert_file: $CF_INSTANCE_CERT"
+    echo "  key_file: $CF_INSTANCE_KEY"
+} > web-config.yml

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -9,4 +9,7 @@ applications:
       - binary_buildpack
     processes:
       - type: web
-        command: ./install_prometheus.sh && ./prometheus --web.listen-address="0.0.0.0:$PORT" --storage.tsdb.retention.size="950MB"
+        command: |
+          ./install_prometheus.sh && \
+          ./create_web_config.sh && \
+          ./prometheus --web.listen-address="0.0.0.0:$PORT" --storage.tsdb.retention.size="950MB" --web.config.file=web-config.yml


### PR DESCRIPTION
Use the Cloud Foundry Instance Identity Credentials (see
https://docs.cloudfoundry.org/devguide/deploy-apps/instance-identity.html)
to enable operating the Prometheus server using HTTPS instead
of HTTP.
