### PR TITLE
Switch alert config to use new idva-alerts channel

### DIFF
--- a/alertmanager/alert-config.yml
+++ b/alertmanager/alert-config.yml
@@ -10,7 +10,7 @@ route:
 receivers:
   - name: 'web.hook'
     slack_configs:
-      - channel: '#idva-dev'
+      - channel: '#idva-alerts'
         text: |
           Environment: ${ENVIRONMENT_NAME}
           Summary: {{ .CommonAnnotations.summary }}


### PR DESCRIPTION
Modifies the alerting config to send alerts to a new #idva-alerts channel specifically for the
monitoring/alerting system notifications. GitHub secret containing the slack webhook has
also been updated to reflect the new URL.