### PR TITLE
fix config check

### DIFF
--- a/.github/workflows/check-config.yaml
+++ b/.github/workflows/check-config.yaml
@@ -1,12 +1,13 @@
 ---
-# The check-config workflow will run the Prometheus 'promtool check config'
-# command to validate the configuration file.
+# The check-config workflow will run the Prometheus 'promtool' and
+# 'amtool' config validation checks against the config files in the repo.
 name: Check-Config
 
 on:
   pull_request:
     paths:
       - '**/prometheus-config.yml'
+      - '**/alert-config.yml'
 
 jobs:
   check-config:
@@ -14,15 +15,23 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Generate config
+      - name: Generate config files
         run: |
           envsubst < prometheus/prometheus-config.yml > prometheus/prometheus.yml
+          envsubst < alertmanager/alert-config.yml > alertmanager/alertmanager.yml
         env:
           # Use 'fake' environment variables since we're just checking syntax
           ENVIRONMENT_NAME: dev
+          SLACK_URL: https://slack.com
 
       - name: Validate Prometheus Config
         run: |
           ./install_prometheus.sh
           ./promtool check config prometheus.yml
         working-directory: ./prometheus
+
+      - name: Validate Alertmanager Config
+        run: |
+          ./install_alertmanager.sh
+          ./amtool check-config alertmanager.yml
+        working-directory: ./alertmanager

--- a/.github/workflows/check-config.yaml
+++ b/.github/workflows/check-config.yaml
@@ -6,7 +6,7 @@ name: Check-Config
 on:
   pull_request:
     paths:
-      - 'prometheus.yml'
+      - '**/prometheus-config.yml'
 
 jobs:
   check-config:

--- a/.github/workflows/check-config.yaml
+++ b/.github/workflows/check-config.yaml
@@ -28,6 +28,7 @@ jobs:
         run: |
           ./install_prometheus.sh
           ./promtool check config prometheus.yml
+          ./promtool check rules rules.yml
         working-directory: ./prometheus
 
       - name: Validate Alertmanager Config

--- a/.github/workflows/check-config.yaml
+++ b/.github/workflows/check-config.yaml
@@ -14,6 +14,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Generate config
+        run: |
+          envsubst < prometheus/prometheus-config.yml > prometheus/prometheus.yml
+        env:
+          # Use 'fake' environment variables since we're just checking syntax
+          ENVIRONMENT_NAME: dev
+
       - name: Validate Prometheus Config
         run: |
           ./install_prometheus.sh

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -34,6 +34,7 @@ jobs:
         run: |
           ./install_prometheus.sh
           ./promtool check config prometheus.yml
+          ./promtool check rules rules.yml
         working-directory: ./prometheus
 
       - name: Validate Alertmanager Config

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -36,6 +36,12 @@ jobs:
           ./promtool check config prometheus.yml
         working-directory: ./prometheus
 
+      - name: Validate Alertmanager Config
+        run: |
+          ./install_alertmanager.sh
+          ./amtool check-config alertmanager.yml
+        working-directory: ./alertmanager
+
   deploy:
     if: github.repository_owner == '18F'
     needs: check-config

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -21,6 +21,15 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Generate config files
+        run: |
+          envsubst < prometheus/prometheus-config.yml > prometheus/prometheus.yml
+          envsubst < alertmanager/alert-config.yml > alertmanager/alertmanager.yml
+        env:
+          # Use 'fake' environment variables since we're just checking syntax
+          ENVIRONMENT_NAME: dev
+          SLACK_URL: https://slack.com
+
       - name: Validate Prometheus Config
         run: |
           ./install_prometheus.sh


### PR DESCRIPTION
Currently, the config check is doing nothing. It worked at one point, but the repo structure and workflow has changed since then and the github actions weren't updated to match. It is currently set to trigger on the wrong file, and even then it's only checking the Prometheus configuration. The changes here will correct the workflows and add validation for Alertmanager configs via the `amtool` provided with Alertmanager.

- Fix file name for config validation check
- Add step to generate config before validtion
- Add config validation for alertmanager config
- Generate config files before usage
- Include validation for alertmanager config file
