### PR TITLE
Remove custom scrape and evaluation intervals

### DIFF
--- a/prometheus/prometheus-config.yml
+++ b/prometheus/prometheus-config.yml
@@ -1,7 +1,5 @@
 ---
 global:
-  scrape_interval: 15s  # Set scrape interval to 15s. Default is 1 minute
-  evaluation_interval: 15s  # Evaluate rules every 15s. Default is 1 minute
 
 # Alertmanager configuration
 alerting:


### PR DESCRIPTION
This repo started using Prometheus with a config file that set the
scrape_interval and evaluation_interval to 15s each. The value was
chosen without much forethought, and hasn't been re-evaluated since.
By setting these values back to their defaults (1m), we get the
following benefits:

1) 75% reduction in data generated by Prometheus.
2) 75% reduction in network activity generated by Prometheus

This should result in much less storage and overall pressure on the
monitoring system. The only expected and valid question left to
answer is "will this affect our monitoring since we aren't evaluating
as often?". Each of our rules defined in rules.yml are either
aggregating data over the last 5m or are using another method to alert.
This means that we don't currently have any rules that would require us
to have such fine-grained data resolution. Additionally, our hardware
metrics are being updated by the cf-metrics service at an interval of 60
seconds, meaning that we are scraping the same duplicate hardare metrics
3 additional times per minute with no added value.
