### PR TITLE
Bump Prometheus version from 2.30.1 -> 2.30.2

### DIFF
--- a/prometheus/install_prometheus.sh
+++ b/prometheus/install_prometheus.sh
@@ -5,8 +5,8 @@ download_output_file="prometheus.tar.gz"
 
 # To update prometheus, update the download URL and checksum below.
 # New versions can be found at https://prometheus.io/download/
-download_url="https://github.com/prometheus/prometheus/releases/download/v2.30.1/prometheus-2.30.1.linux-amd64.tar.gz"
-valid_hash="9c542a653bf2f17043056ca13ea428e56ff2f677ee03bf7494aa2efe2b8329a3  $download_output_file"
+download_url="https://github.com/prometheus/prometheus/releases/download/v2.30.2/prometheus-2.30.2.linux-amd64.tar.gz"
+valid_hash="1f5c239f6fa8da511ae140eea8d3190c1a6e0093247d758d81c99d63684ae1e1  $download_output_file"
 
 # Download the Prometheus archive
 wget --quiet --output-document "$download_output_file" "$download_url"


### PR DESCRIPTION
[Prometheus 2.30.2 release](https://github.com/prometheus/prometheus/releases/tag/v2.30.2)