### PR TITLE
Remove manual hash validation

### DIFF
--- a/alertmanager/install_alertmanager.sh
+++ b/alertmanager/install_alertmanager.sh
@@ -1,18 +1,21 @@
 #!/bin/bash
 set -e
 
-download_output_file="alertmanager.tar.gz"
+# To update alertmanager, simply update the version number below
+version_num="0.23.0"
+download_url="https://github.com/prometheus/alertmanager/releases/download/v$version_num"
+archive_name="alertmanager-$version_num.linux-amd64.tar.gz"
 
-# To update alertmanager, update the download URL and hash below.
-download_url="https://github.com/prometheus/alertmanager/releases/download/v0.23.0/alertmanager-0.23.0.linux-amd64.tar.gz"
-valid_hash="77793c4d9bb92be98f7525f8bc50cb8adb8c5de2e944d5500e90ab13918771fc  $download_output_file"
+archive_url="$download_url/$archive_name"
+shasum_url="$download_url/sha256sums.txt"
 
-# Download the Prometheus archive
-wget --quiet --output-document "$download_output_file" "$download_url"
+# Download the Alertmanager archive and shasum file
+wget --quiet "$archive_url"
+wget --quiet "$shasum_url"
 
 # Compare sha256sum
-echo "$valid_hash" | sha256sum --check --quiet
+sha256sum --check --ignore-missing --status sha256sums.txt
 
 # Extract the archive to the current directory, preserving the existing prometheus.yml
-tar -xzf "$download_output_file" --strip-components 1 --skip-old-files
-rm "$download_output_file"
+tar -xzf $archive_name --strip-components 1 --skip-old-files
+rm "$archive_name" sha256sums.txt

--- a/prometheus/install_prometheus.sh
+++ b/prometheus/install_prometheus.sh
@@ -1,19 +1,21 @@
 #!/bin/bash
 set -e
 
-download_output_file="prometheus.tar.gz"
+# To update Prometheus, simply update the version number below
+version_num="2.30.2"
+download_url="https://github.com/prometheus/prometheus/releases/download/v$version_num"
+archive_name="prometheus-$version_num.linux-amd64.tar.gz"
 
-# To update prometheus, update the download URL and checksum below.
-# New versions can be found at https://prometheus.io/download/
-download_url="https://github.com/prometheus/prometheus/releases/download/v2.30.2/prometheus-2.30.2.linux-amd64.tar.gz"
-valid_hash="1f5c239f6fa8da511ae140eea8d3190c1a6e0093247d758d81c99d63684ae1e1  $download_output_file"
+archive_url="$download_url/$archive_name"
+shasum_url="$download_url/sha256sums.txt"
 
-# Download the Prometheus archive
-wget --quiet --output-document "$download_output_file" "$download_url"
+# Download the Prometheus archive and shasum file
+wget --quiet "$archive_url"
+wget --quiet "$shasum_url"
 
 # Compare sha256sum
-echo "$valid_hash" | sha256sum --check --quiet
+sha256sum --check --ignore-missing --status sha256sums.txt
 
 # Extract the archive to the current directory, preserving the existing prometheus.yml
-tar -xzf "$download_output_file" --strip-components 1 --skip-old-files
-rm "$download_output_file"
+tar -xzf $archive_name --strip-components 1 --skip-old-files
+rm "$archive_name" sha256sums.txt


### PR DESCRIPTION
Prior to this change, updating the version of Prometheus or Alertmanager
meant changing the version number in several places in the installation
script as well as manually providing the hash for the tar files (see
https://github.com/18F/identity-idva-monitoring/pull/45/files). With
this change, users can update the version_num variable in one place at
the top of the script, and the URLs for the tar and the shasum file are
built by the script. This eliminates the possibility for human error and
typos and will always result in the version specified being installed.
