### PR TITLE
Use local workflow reference to prevent duplication

### DIFF
--- a/.github/workflows/check-config.yaml
+++ b/.github/workflows/check-config.yaml
@@ -8,6 +8,7 @@ on:
     paths:
       - '**/prometheus-config.yml'
       - '**/alert-config.yml'
+  workflow_call:
 
 jobs:
   check-config:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -19,29 +19,11 @@ jobs:
   check-config:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Check out repository
+        uses: actions/checkout@v2
 
-      - name: Generate config files
-        run: |
-          envsubst < prometheus/prometheus-config.yml > prometheus/prometheus.yml
-          envsubst < alertmanager/alert-config.yml > alertmanager/alertmanager.yml
-        env:
-          # Use 'fake' environment variables since we're just checking syntax
-          ENVIRONMENT_NAME: dev
-          SLACK_URL: https://slack.com
-
-      - name: Validate Prometheus Config
-        run: |
-          ./install_prometheus.sh
-          ./promtool check config prometheus.yml
-          ./promtool check rules rules.yml
-        working-directory: ./prometheus
-
-      - name: Validate Alertmanager Config
-        run: |
-          ./install_alertmanager.sh
-          ./amtool check-config alertmanager.yml
-        working-directory: ./alertmanager
+      - name: Run config validation
+        uses: ./.github/actions/check-config
 
   deploy:
     if: github.repository_owner == '18F'

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -17,13 +17,7 @@ on:
 
 jobs:
   check-config:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v2
-
-      - name: Run config validation
-        uses: ./.github/actions/check-config
+    uses: 18F/identity-idva-monitoring/.github/workflows/check-config.yaml@main
 
   deploy:
     if: github.repository_owner == '18F'


### PR DESCRIPTION
To prevent duplication of the config validation action code, a workflow
can and should reference the existing workflow within the repository.
See https://docs.github.com/en/actions/learn-github-actions/reusing-workflows
