### PR TITLE
Fix broken route in prometheus datasource configuration

### DIFF
--- a/grafana/conf/provisioning/datasources/prometheus.yaml
+++ b/grafana/conf/provisioning/datasources/prometheus.yaml
@@ -5,7 +5,7 @@ datasources:
   - name: idva-monitoring-data
     type: prometheus
     access: proxy
-    url: https://identity-idva-monitoring-${ENVIRONMENT_NAME}.apps.internal:$PORT
+    url: https://identity-idva-monitoring-prometheus-${ENVIRONMENT_NAME}.apps.internal:$PORT
     isDefault: true
     editable: false
     jsonData:


### PR DESCRIPTION
Fix broken route in Prometheus datasource configuration causing Grafana to fail to pull Prometheus data.