### PR TITLE
add external labels

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -32,7 +32,6 @@ jobs:
 
       - name: Generate config files
         run: |
-          envsubst < prometheus/prometheus-config.yml > prometheus/prometheus.yml
           envsubst < alertmanager/alert-config.yml > alertmanager/alertmanager.yml
         env:
           ENVIRONMENT_NAME: ${{ steps.cf-setup.outputs.target-environment }}

--- a/prometheus/apt.yml
+++ b/prometheus/apt.yml
@@ -1,0 +1,3 @@
+---
+packages:
+  - gettext-base  # Installs 'envsubst' command

--- a/prometheus/manifest.yaml
+++ b/prometheus/manifest.yaml
@@ -13,3 +13,5 @@ applications:
       ./install_prometheus.sh && \
       ./create_web_config.sh && \
       ./prometheus --web.listen-address="0.0.0.0:$PORT" --storage.tsdb.retention.size="950MB" --web.config.file=web-config.yml
+    env:
+      ENVIRONMENT_NAME: ((ENVIRONMENT_NAME))

--- a/prometheus/manifest.yaml
+++ b/prometheus/manifest.yaml
@@ -9,6 +9,7 @@ applications:
       - https://github.com/cloudfoundry/apt-buildpack
       - binary_buildpack
     command: |
+      envsubst < prometheus-config.yml > prometheus.yml
       ./install_prometheus.sh && \
       ./create_web_config.sh && \
       ./prometheus --web.listen-address="0.0.0.0:$PORT" --storage.tsdb.retention.size="950MB" --web.config.file=web-config.yml

--- a/prometheus/manifest.yaml
+++ b/prometheus/manifest.yaml
@@ -6,6 +6,7 @@ applications:
     memory: ((MEMORY))
     instances: ((INSTANCES))
     buildpacks:
+      - https://github.com/cloudfoundry/apt-buildpack
       - binary_buildpack
     command: |
       ./install_prometheus.sh && \

--- a/prometheus/prometheus-config.yml
+++ b/prometheus/prometheus-config.yml
@@ -3,7 +3,7 @@ global:
   # The labels to add to any time series or alerts when communicating with
   # external systems (federation, remote storage, Alertmanager).
   external_labels:
-    cluster: idva-prometheus-1
+    cluster: idva-prometheus
     __replica__: replica-${CF_INSTANCE_INDEX}
 
 # Alertmanager configuration

--- a/prometheus/prometheus-config.yml
+++ b/prometheus/prometheus-config.yml
@@ -1,5 +1,10 @@
 ---
 global:
+  # The labels to add to any time series or alerts when communicating with
+  # external systems (federation, remote storage, Alertmanager).
+  external_labels:
+    cluster: idva-prometheus-1
+    __replica__: replica-${CF_INSTANCE_INDEX}
 
 # Alertmanager configuration
 alerting:


### PR DESCRIPTION
- Add apt buildpack to install envsubst
- Move config generation within manifest command
- Add external labels to support long-term storage

Following the [Cortex documentation](https://cortexmetrics.io/docs/guides/ha-pair-handling/#client-side),
this PR will add two external labels to our metric data. The "__replica__" label is required to be unique in order
to de-duplicate incoming metric streams so I've relied on the CF_INSTANCE_INDEX environment variable to
accomplish this. That change in turn required changing where the 'envsubst' command is run, changing from
our actions pipeline, to the manifest file.

Existing config-validation being done in GitHub Actions should be unaffected by this change.