### PR TITLE
Improve alerts formating

### DIFF
--- a/alertmanager/alert-config.yml
+++ b/alertmanager/alert-config.yml
@@ -2,7 +2,7 @@
 global:
   slack_api_url: ${SLACK_URL}
 route:
-  group_by: ['alertname']
+  group_by: ['...']
   group_wait: 30s
   group_interval: 5m
   repeat_interval: 1h
@@ -11,10 +11,13 @@ receivers:
   - name: 'web.hook'
     slack_configs:
       - channel: '#idva-alerts'
+        title: |-
+          {{ "${ENVIRONMENT_NAME}" | toUpper }} - {{ .CommonLabels.app }} - {{ .CommonLabels.alertname }}  {{ .CommonAnnotations.icon }}
+        color: |-
+          {{ if eq "${ENVIRONMENT_NAME}" "prod" }}#ff0000{{ else if eq "${ENVIRONMENT_NAME}" "test" }}#0000ff{{ else }}#000000{{ end }}
         text: |
-          Environment: ${ENVIRONMENT_NAME}
           Summary: {{ .CommonAnnotations.summary }}
-          Description: {{ .CommonAnnotations.description }}
+          {{ .CommonAnnotations.description }}
 inhibit_rules:
   - source_match:
       severity: 'critical'

--- a/alertmanager/alert-config.yml
+++ b/alertmanager/alert-config.yml
@@ -12,7 +12,7 @@ receivers:
     slack_configs:
       - channel: '#idva-alerts'
         title: |-
-          {{ "${ENVIRONMENT_NAME}" | toUpper }} - {{ .CommonLabels.app }} - {{ .CommonLabels.alertname }}  {{ .CommonAnnotations.icon }}
+          {{ "${ENVIRONMENT_NAME}" | toUpper }} – {{ .CommonLabels.app }} – {{ .CommonLabels.alertname }}  {{ .CommonAnnotations.icon }}
         color: |-
           {{ if eq "${ENVIRONMENT_NAME}" "prod" }}#ff0000{{ else if eq "${ENVIRONMENT_NAME}" "test" }}#0000ff{{ else }}#000000{{ end }}
         text: |

--- a/prometheus/prometheus-config.yml
+++ b/prometheus/prometheus-config.yml
@@ -8,6 +8,9 @@ global:
 
 # Alertmanager configuration
 alerting:
+  alert_relabel_configs:
+    - action: labeldrop
+      regex: __replica__
   alertmanagers:
     - dns_sd_configs:
         - names:

--- a/prometheus/rules.yml
+++ b/prometheus/rules.yml
@@ -11,6 +11,7 @@ groups:
             {{ $labels.app }}.
           description: >-
             CPU load has exceeded 80% for at least 5 consecutive minutes.
+          icon: 🖥️
 
       - alert: High memory utilization
         expr: avg by (app) (avg_over_time(memory_utilization[5m])) > 80
@@ -20,6 +21,7 @@ groups:
             {{ $labels.app }}.
           description: >-
             Memory usage has exceeded 80% for at least 5 consecutive minutes.
+          icon: 💾
 
       - alert: High disk utilization
         expr: avg by (app) (avg_over_time(disk_utilization[5m])) > 80
@@ -29,6 +31,7 @@ groups:
             {{ $labels.app }}.
           description: >-
             Disk usage has exceeded 80% for at least 5 consecutive minutes.
+          icon: 📁
 
       # No utilization alerts
       - alert: No CPU utilization
@@ -59,6 +62,7 @@ groups:
           description: >-
             Over the last minute, the rate of unauthorized (401 or 403)
             responses was {{ $value | printf "%.2f"}}/second.
+          icon: ⛔
 
       # 5XX error responses
       - alert: Server Errors
@@ -70,6 +74,7 @@ groups:
           description: >-
             The {{ $labels.app }} service may be experiencing issues and has
             returned at least 1 5XX response in the last 5 minutes.
+          icon: ❌
 
   - name: ResponseTimeAlerts
     rules:
@@ -94,6 +99,7 @@ groups:
           description: >-
             More than 5% of requests to {{ $labels.service }} are taking longer
             than 1000ms to complete.
+          icon: 🐢
 
   - name: AppCrashAlerts
     rules:
@@ -104,3 +110,4 @@ groups:
           description: >-
             Within the last 5 minutes, the {{ $labels.app }} has crashed at
             least once.
+          icon: 🔥


### PR DESCRIPTION
This alert formatting differs from the norm. By disabling aggregation, each slack message can be known to contain only a single alert, simplifying message formatting in exchange for potentially more messages.

Sample:
![image](https://user-images.githubusercontent.com/1097369/143197008-db1a9af1-20a5-449f-bda8-2b552c14aa97.png)
