### PR TITLE
Add external urls to alertmanager and prometheus.

### DIFF
--- a/alertmanager/manifest.yaml
+++ b/alertmanager/manifest.yaml
@@ -10,7 +10,10 @@ applications:
     command: |
       ./install_alertmanager.sh && \
       ./create_web_config.sh && \
-      ./alertmanager --web.listen-address="0.0.0.0:$PORT" --cluster.peer="identity-idva-monitoring-alertmanager-((ENVIRONMENT_NAME)).apps.internal:9094" --web.config.file=web-config.yml
+      ./alertmanager --web.listen-address="0.0.0.0:$PORT" \
+          --cluster.peer="identity-idva-monitoring-alertmanager-((ENVIRONMENT_NAME)).apps.internal:9094" \
+          --web.config.file=web-config.yml \
+          --web.external-url https://identity-idva-monitoring-alertmanager-((ENVIRONMENT_NAME)).apps.internal/
     env:
       SLACK_URL: ((SLACK_URL))
       ENVIRONMENT_NAME: ((ENVIRONMENT_NAME))

--- a/prometheus/manifest.yaml
+++ b/prometheus/manifest.yaml
@@ -12,6 +12,9 @@ applications:
       envsubst < prometheus-config.yml > prometheus.yml
       ./install_prometheus.sh && \
       ./create_web_config.sh && \
-      ./prometheus --web.listen-address="0.0.0.0:$PORT" --storage.tsdb.retention.size="950MB" --web.config.file=web-config.yml
+      ./prometheus --web.listen-address="0.0.0.0:$PORT" \
+          --storage.tsdb.retention.size="950MB" \
+          --web.config.file=web-config.yml \
+          --web.external-url https://identity-idva-monitoring-prometheus-((ENVIRONMENT_NAME)).apps.internal/
     env:
       ENVIRONMENT_NAME: ((ENVIRONMENT_NAME))


### PR DESCRIPTION
Add external urls to alertmanager and prometheus. In combination with an appropriate hosts file, this will allow links in the alert messages to work correctly