### PR TITLE
correct route name

### DIFF
--- a/cortex/manifest.yaml
+++ b/cortex/manifest.yaml
@@ -2,7 +2,7 @@
 applications:
   - name: cortex
     routes:
-      - route: identity-idva-cortex-((ENVIRONMENT_NAME)).apps.internal
+      - route: identity-idva-monitoring-cortex-((ENVIRONMENT_NAME)).apps.internal
     memory: ((MEMORY))
     instances: ((INSTANCES))
     buildpacks:

--- a/prometheus/prometheus-config.yml
+++ b/prometheus/prometheus-config.yml
@@ -27,7 +27,7 @@ rule_files:
   - "rules.yml"
 
 remote_write:
-  - url: https://identity-idva-cortex-${ENVIRONMENT_NAME}.apps.internal:8080/api/v1/push
+  - url: https://identity-idva-monitoring-cortex-${ENVIRONMENT_NAME}.apps.internal:8080/api/v1/push
     tls_config:
       insecure_skip_verify: true
 


### PR DESCRIPTION
- Fix cortex route to match naming standard for monitoring apps
- Correct Cortex URL in prometheus remote-write config section
