### PR TITLE
download files in cicd

### DIFF
--- a/.github/workflows/deploy-grafana.yaml
+++ b/.github/workflows/deploy-grafana.yaml
@@ -28,8 +28,12 @@ jobs:
           cf-password: ${{ secrets.CF_PASSWORD }}
           cf-org: ${{ secrets.CF_ORG }}
 
+      - name: Install Grafana
+        run: ./install_grafana.sh
+        working-directory: ./grafana
+
       - name: Deploy Grafana
-        run: ./install_grafana.sh && cf push
+        run: cf push
           --var ENVIRONMENT_NAME=${{ steps.cf-setup.outputs.target-environment }}
           --var GRAFANA_PASS=${{ secrets.GRAFANA_PASS }}
           --strategy rolling

--- a/.github/workflows/deploy-grafana.yaml
+++ b/.github/workflows/deploy-grafana.yaml
@@ -29,7 +29,7 @@ jobs:
           cf-org: ${{ secrets.CF_ORG }}
 
       - name: Deploy Grafana
-        run: cf push
+        run: ./install_grafana.sh && cf push
           --var ENVIRONMENT_NAME=${{ steps.cf-setup.outputs.target-environment }}
           --var GRAFANA_PASS=${{ secrets.GRAFANA_PASS }}
           --strategy rolling

--- a/.github/workflows/deploy-prometheus.yaml
+++ b/.github/workflows/deploy-prometheus.yaml
@@ -33,7 +33,7 @@ jobs:
           cf-org: ${{ secrets.CF_ORG }}
 
       - name: Deploy Prometheus
-        run: cf push --vars-file vars.yaml
+        run: ./install_prometheus.sh && cf push --vars-file vars.yaml
           --var ENVIRONMENT_NAME=${{ steps.cf-setup.outputs.target-environment }}
           --strategy rolling
         working-directory: ./prometheus

--- a/.github/workflows/deploy-prometheus.yaml
+++ b/.github/workflows/deploy-prometheus.yaml
@@ -32,8 +32,12 @@ jobs:
           cf-password: ${{ secrets.CF_PASSWORD }}
           cf-org: ${{ secrets.CF_ORG }}
 
+      - name: Install Prometheus
+        run: ./install_prometheus.sh
+        working-directory: ./prometheus
+
       - name: Deploy Prometheus
-        run: ./install_prometheus.sh && cf push --vars-file vars.yaml
+        run: cf push --vars-file vars.yaml
           --var ENVIRONMENT_NAME=${{ steps.cf-setup.outputs.target-environment }}
           --strategy rolling
         working-directory: ./prometheus

--- a/grafana/manifest.yaml
+++ b/grafana/manifest.yaml
@@ -11,4 +11,4 @@ applications:
     env:
       ENVIRONMENT_NAME: ((ENVIRONMENT_NAME))
       GRAFANA_PASS: ((GRAFANA_PASS))
-    command: ./install_grafana.sh && ./bin/grafana-server web
+    command: ./bin/grafana-server web

--- a/prometheus/create_web_config.sh
+++ b/prometheus/create_web_config.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-# See https://docs.cloudfoundry.org/devguide/deploy-apps/instance-identity.html
-# for information on Cloud Foundry Instance Identity Credentials.
-{
-    echo "---"
-    echo "tls_server_config:"
-    echo "  cert_file: $CF_INSTANCE_CERT"
-    echo "  key_file: $CF_INSTANCE_KEY"
-} > web-config.yml

--- a/prometheus/manifest.yaml
+++ b/prometheus/manifest.yaml
@@ -9,12 +9,7 @@ applications:
       - https://github.com/cloudfoundry/apt-buildpack
       - binary_buildpack
     command: |
-      envsubst < prometheus-config.yml > prometheus.yml
-      ./install_prometheus.sh && \
-      ./create_web_config.sh && \
-      ./prometheus --web.listen-address="0.0.0.0:$PORT" \
-          --storage.tsdb.retention.size="950MB" \
-          --web.config.file=web-config.yml \
-          --web.external-url https://identity-idva-monitoring-prometheus-((ENVIRONMENT_NAME)).apps.internal/
+      # Use 'source' to prevent creating a new shell process for 'run.sh'
+      source run.sh
     env:
       ENVIRONMENT_NAME: ((ENVIRONMENT_NAME))

--- a/prometheus/run.sh
+++ b/prometheus/run.sh
@@ -1,0 +1,11 @@
+web_config_name="web-config.yml"
+
+# Generate config files
+envsubst < prometheus-config.yml > prometheus.yml
+envsubst < web-config-template.yml > "$web_config_name"
+
+./prometheus \
+  --web.listen-address="0.0.0.0:$PORT" \
+  --storage.tsdb.retention.size="950MB" \
+  --web.config.file="$web_config_name" \
+  --web.external-url https://identity-idva-monitoring-prometheus-"$ENVIRONMENT_NAME".apps.internal/

--- a/prometheus/web-config-template.yml
+++ b/prometheus/web-config-template.yml
@@ -1,0 +1,4 @@
+---
+tls_server_config:
+  cert_file: ${CF_INSTANCE_CERT}
+  key_file: ${CF_INSTANCE_KEY}


### PR DESCRIPTION
- Download Prometheus files prior to cf deployment
- Download Grafana files prior to cf deployment
- Move install to separate action step

This update moves the installation process for IDVA monitoring tools from within the cloud.gov environment to their respective GitHub Actions run. This will prevent deployments from failing when IDVA switches to controlled-egress spaces within cloud.gov.

The following tools will be in public-egress spaces and thus do not need their installation processes installed:

* Cortex: Relies on reaching S3, which currently has to be done via a public-egress space
* Alertmanager: Sends alerts to public notification endpoints
* Watchtower: Queries the public Cloud.gov API endpoints