### PR TITLE
Migrate app spaces

### DIFF
--- a/.github/workflows/deploy-alertmanager.yaml
+++ b/.github/workflows/deploy-alertmanager.yaml
@@ -31,6 +31,7 @@ jobs:
           cf-username: ${{ secrets.CF_USERNAME }}
           cf-password: ${{ secrets.CF_PASSWORD }}
           cf-org: ${{ secrets.CF_ORG }}
+          space-suffix: "-public"
 
       - name: Generate config files
         run: |

--- a/.github/workflows/deploy-alertmanager.yaml
+++ b/.github/workflows/deploy-alertmanager.yaml
@@ -33,6 +33,10 @@ jobs:
           cf-org: ${{ secrets.CF_ORG }}
           space-suffix: "-public"
 
+      - name: Install Alertmanager
+        run: ./install_alertmanager.sh
+        working-directory: ./alertmanager
+
       - name: Generate config files
         run: |
           envsubst < alertmanager/alert-config.yml > alertmanager/alertmanager.yml

--- a/.github/workflows/deploy-cortex.yaml
+++ b/.github/workflows/deploy-cortex.yaml
@@ -27,6 +27,7 @@ jobs:
           cf-username: ${{ secrets.CF_USERNAME }}
           cf-password: ${{ secrets.CF_PASSWORD }}
           cf-org: ${{ secrets.CF_ORG }}
+          space-suffix: "-public"
 
       - name: Deploy Cortex
         run: cf push --vars-file vars.yaml
@@ -36,5 +37,10 @@ jobs:
 
       - name: Apply CF Network Policies
         run: |
-          cf add-network-policy prometheus cortex
-          cf add-network-policy grafana cortex
+          restricted_space=${{ steps.cf-setup.outputs.target-environment }}
+          public_space=${{ steps.cf-setup.outputs.target-environment }}-public
+
+          # Apps that need to communicate to cortex are in restricted space
+          cf target -s "$restricted_space"
+          cf add-network-policy prometheus cortex -s "$public_space"
+          cf add-network-policy grafana cortex -s "$public_space"

--- a/.github/workflows/deploy-cortex.yaml
+++ b/.github/workflows/deploy-cortex.yaml
@@ -29,6 +29,10 @@ jobs:
           cf-org: ${{ secrets.CF_ORG }}
           space-suffix: "-public"
 
+      - name: Install Cortex
+        run: ./install_cortex.sh
+        working-directory: ./cortex
+
       - name: Deploy Cortex
         run: cf push --vars-file vars.yaml
           --var ENVIRONMENT_NAME=${{ steps.cf-setup.outputs.target-environment }}

--- a/.github/workflows/deploy-cortex.yaml
+++ b/.github/workflows/deploy-cortex.yaml
@@ -37,10 +37,10 @@ jobs:
 
       - name: Apply CF Network Policies
         run: |
-          restricted_space=${{ steps.cf-setup.outputs.target-environment }}
+          closed_space=${{ steps.cf-setup.outputs.target-environment }}-closed
           public_space=${{ steps.cf-setup.outputs.target-environment }}-public
 
-          # Apps that need to communicate to cortex are in restricted space
-          cf target -s "$restricted_space"
+          # Apps that need to communicate to cortex are in closed space
+          cf target -s "$closed_space"
           cf add-network-policy prometheus cortex -s "$public_space"
           cf add-network-policy grafana cortex -s "$public_space"

--- a/.github/workflows/deploy-grafana.yaml
+++ b/.github/workflows/deploy-grafana.yaml
@@ -27,6 +27,7 @@ jobs:
           cf-username: ${{ secrets.CF_USERNAME }}
           cf-password: ${{ secrets.CF_PASSWORD }}
           cf-org: ${{ secrets.CF_ORG }}
+          space-suffix: "-closed"
 
       - name: Install Grafana
         run: ./install_grafana.sh

--- a/.github/workflows/deploy-prometheus.yaml
+++ b/.github/workflows/deploy-prometheus.yaml
@@ -51,4 +51,4 @@ jobs:
           cf add-network-policy prometheus redis-metrics
           cf add-network-policy prometheus elasticsearch-metrics
           cf add-network-policy prometheus kong --port 8100 --protocol tcp
-          cf add-network-policy prometheus watchtower
+          cf add-network-policy prometheus watchtower -s "$public_space"

--- a/.github/workflows/deploy-prometheus.yaml
+++ b/.github/workflows/deploy-prometheus.yaml
@@ -31,6 +31,7 @@ jobs:
           cf-username: ${{ secrets.CF_USERNAME }}
           cf-password: ${{ secrets.CF_PASSWORD }}
           cf-org: ${{ secrets.CF_ORG }}
+          space-suffix: "-closed"
 
       - name: Install Prometheus
         run: ./install_prometheus.sh
@@ -45,10 +46,11 @@ jobs:
       - name: Apply CF Network Policies
         run: |
           public_space=${{ steps.cf-setup.outputs.target-environment }}-public
+          restricted_space=${{ steps.cf-setup.outputs.target-environment }}
 
           cf add-network-policy prometheus alertmanager -s "$public_space"
-          cf add-network-policy prometheus cf-metrics
-          cf add-network-policy prometheus redis-metrics
-          cf add-network-policy prometheus elasticsearch-metrics
-          cf add-network-policy prometheus kong --port 8100 --protocol tcp
+          cf add-network-policy prometheus cf-metrics -s "$restricted_space"
+          cf add-network-policy prometheus redis-metrics -s "$restricted_space"
+          cf add-network-policy prometheus elasticsearch-metrics -s "$restricted_space"
+          cf add-network-policy prometheus kong --port 8100 --protocol tcp -s "$restricted_space"
           cf add-network-policy prometheus watchtower -s "$public_space"

--- a/.github/workflows/deploy-prometheus.yaml
+++ b/.github/workflows/deploy-prometheus.yaml
@@ -44,7 +44,9 @@ jobs:
 
       - name: Apply CF Network Policies
         run: |
-          cf add-network-policy prometheus alertmanager
+          public_space=${{ steps.cf-setup.outputs.target-environment }}-public
+
+          cf add-network-policy prometheus alertmanager -s "$public_space"
           cf add-network-policy prometheus cf-metrics
           cf add-network-policy prometheus redis-metrics
           cf add-network-policy prometheus elasticsearch-metrics

--- a/.github/workflows/deploy-watchtower.yaml
+++ b/.github/workflows/deploy-watchtower.yaml
@@ -27,6 +27,7 @@ jobs:
           cf-username: ${{ secrets.CF_USERNAME }}
           cf-password: ${{ secrets.CF_PASSWORD }}
           cf-org: ${{ secrets.CF_ORG }}
+          space-suffix: "-public"
 
       - name: Set audit user credentials
         run: |

--- a/alertmanager/manifest.yaml
+++ b/alertmanager/manifest.yaml
@@ -8,7 +8,6 @@ applications:
     buildpacks:
       - binary_buildpack
     command: |
-      ./install_alertmanager.sh && \
       ./create_web_config.sh && \
       ./alertmanager --web.listen-address="0.0.0.0:$PORT" \
           --cluster.peer="identity-idva-monitoring-alertmanager-((ENVIRONMENT_NAME)).apps.internal:9094" \

--- a/cortex/manifest.yaml
+++ b/cortex/manifest.yaml
@@ -10,7 +10,6 @@ applications:
     services:
       - prometheus-storage
     command: |
-      ./install_cortex.sh
       export BUCKET_NAME=$(echo $VCAP_SERVICES | jq '.s3[0].credentials.bucket')
       export BUCKET_ENDPOINT=$(echo $VCAP_SERVICES | jq '.s3[0].credentials.fips_endpoint')
       export AWS_REGION=$(echo $VCAP_SERVICES | jq '.s3[0].credentials.region')


### PR DESCRIPTION
Most notably this PR will put Prometheus and Grafana in "closed" egress spaces. Watchtower, Cortex, and Alertmanager will move to explicit "public" egress spaces in anticipation of the default "dev|test|prod" spaces switching to a "restricted" space egress type.

Additionally, Cortex and Alertmanager have both had their tool installation processes moved into GitHub action steps in order to support space egress type changes in the future. By moving the install process completely outside of CloudFoundry, we can arbitrarily switch the targeted space without having to worry about the install process per-tool.