### PR TITLE
Remove "instance" label from alert labels

### DIFF
--- a/prometheus/prometheus-config.yml
+++ b/prometheus/prometheus-config.yml
@@ -11,6 +11,9 @@ alerting:
   alert_relabel_configs:
     - action: labeldrop
       regex: __replica__
+    - action: labeldrop
+      regex: instance
+
   alertmanagers:
     - dns_sd_configs:
         - names:


### PR DESCRIPTION
Removal of the "instance" label should solve the issue of multiple
alerts coming in for apps where multiple instances are running. IDVA
does not, nor should it ever, rely on the IP addresses found in the
"instance" label when deciding whether or not to send an alert. Dropping
this label when sending alerts to alertmanager allows us to receive
fewer alerts while preserving the data in Prometheus should teams need
to troubleshoot and identify problematic app instances.
