### PR TITLE
Add proxy support via .profile initalization script

### DIFF
--- a/watchtower/.profile
+++ b/watchtower/.profile
@@ -1,0 +1,8 @@
+#!/bin/bash
+proxy_url=$(echo "$VCAP_SERVICES" | jq '.["user-provided"][] | select(.name == "outbound-proxy") | .credentials.proxy_url')
+
+# Export the proxy variables if the "proxy_url" variable is not empty
+if [ -n "$proxy_url" ]; then
+  export HTTP_PROXY=$proxy_url
+  export HTTPS_PROXY=$proxy_url
+fi


### PR DESCRIPTION
Add support to use a forward proxy by using a `.profile` cf initialization script. Does nothing if not bound to the `outbound-proxy` user-provided service.