### PR TITLE
Extend duration of "job down" alert rule

### DIFF
--- a/prometheus/rules.yml
+++ b/prometheus/rules.yml
@@ -4,6 +4,7 @@ groups:
     rules:
       - alert: Prometheus Job Down
         expr: avg by (job) (up) != 1
+        for: 5m
         annotations:
           summary: Prometheus scrape job {{ $labels.job }} is down.
           description: >-


### PR DESCRIPTION
In order to compensate for cloud foundry automatically restarting,
restaging, and deployment of applications, extending the duration of the
"job down" alert to 5m gives any application five minutes to have
all instances come back online before deeming a Prometheus scrape job as
down.
