### PR TITLE
Ignore deployment triggers on changes to markdown files

### DIFF
--- a/.github/workflows/deploy-es.yaml
+++ b/.github/workflows/deploy-es.yaml
@@ -10,6 +10,7 @@ on:
     paths:
       - 'elasticsearch/**'
       - '.github/workflows/deploy-es.yaml'
+      - '!**.md'  # Ignore all markdown files in the repository
   release:
     types: [released]
 

--- a/.github/workflows/deploy-redis.yaml
+++ b/.github/workflows/deploy-redis.yaml
@@ -10,6 +10,7 @@ on:
     paths:
       - 'redis/**'
       - '.github/workflows/deploy-redis.yaml'
+      - '!**.md'  # Ignore all markdown files in the repository
   release:
     types: [released]
 


### PR DESCRIPTION
Similar to other deployment workflows, do not initiate deployments on changes to markdown files.