### PR TITLE
TEST - Remove Slack alert template

### DIFF
--- a/alertmanager/alert-config.yml
+++ b/alertmanager/alert-config.yml
@@ -10,11 +10,6 @@ route:
 receivers:
   - name: 'web.hook'
     slack_configs:
-      - channel: '#idva-alerts'
-        title: |-
-          {{ "${ENVIRONMENT_NAME}" | toUpper }} – {{ .CommonLabels.app }} – {{ .CommonLabels.alertname }}  {{ .CommonAnnotations.icon }}
-        color: |-
-          {{ if eq "${ENVIRONMENT_NAME}" "prod" }}#ff0000{{ else if eq "${ENVIRONMENT_NAME}" "test" }}#0000ff{{ else }}#000000{{ end }}
         text: |
           Summary: {{ .CommonAnnotations.summary }}
           {{ .CommonAnnotations.description }}


### PR DESCRIPTION
In order to more quicly discern the important data from the slack alerts
generated by Alertmanager, remove the templating that is modifying the
message structure and allow the alerts to render in their default
format.
