### PR TITLE
grafana use cloud gov cert

### DIFF
--- a/create-network-policies.sh
+++ b/create-network-policies.sh
@@ -24,7 +24,7 @@ cf add-network-policy prometheus alertmanager
 cf add-network-policy prometheus cf-metrics
 cf add-network-policy prometheus cortex
 cf add-network-policy prometheus elasticsearch-metrics
-cf add-network-policy prometheus grafana
+cf add-network-policy prometheus grafana --port 61443 --protocol tcp
 cf add-network-policy prometheus kong --port 8100 --protocol tcp
 cf add-network-policy prometheus redis-metrics
 cf add-network-policy prometheus watchtower

--- a/grafana/conf/custom.ini
+++ b/grafana/conf/custom.ini
@@ -1,8 +1,6 @@
 [server]
-protocol = https
+protocol = http
 http_port = ${PORT}
-cert_file = ${CF_INSTANCE_CERT}
-cert_key = ${CF_INSTANCE_KEY}
 
 [security]
 admin_password = ${GRAFANA_PASS}

--- a/grafana/manifest.yaml
+++ b/grafana/manifest.yaml
@@ -4,6 +4,8 @@ applications:
     stack: cflinuxfs3
     instances: 2
     memory: 256MB
+    health-check-type: http
+    health-check-http-endpoint: /api/health
     buildpacks:
       - https://github.com/cloudfoundry/binary-buildpack
     routes:

--- a/prometheus/prometheus-config.yml
+++ b/prometheus/prometheus-config.yml
@@ -61,10 +61,8 @@ scrape_configs:
 
   - job_name: 'grafana'
     scheme: https
-    tls_config:
-      insecure_skip_verify: true
     static_configs:
-      - targets: ['identity-idva-monitoring-grafana-${ENVIRONMENT_NAME}.apps.internal:8080']
+      - targets: ['identity-idva-monitoring-grafana-${ENVIRONMENT_NAME}.apps.internal:61443']
 
   - job_name: 'watchtower'
     static_configs:


### PR DESCRIPTION
Switching to usage of the cloud.gov `61443` port, which includes the SAN
for cloud.gov apps, allows connecting to Grafana via fully-valid TLS connections.
- Use http health check for Grafana
- Remove direct instance identity cert usage
- Switch to using https port for Grafana