### PR TITLE
monitoring use cloud gov cert

### DIFF
--- a/cortex/config.yaml
+++ b/cortex/config.yaml
@@ -3,9 +3,6 @@ auth_enabled: false
 
 server:
   http_listen_port: ${PORT}
-  http_tls_config:
-    cert_file: ${CF_INSTANCE_CERT}
-    key_file: ${CF_INSTANCE_KEY}
 
   # Configure the server to allow messages up to 100MB.
   grpc_server_max_recv_msg_size: 104857600

--- a/create-network-policies.sh
+++ b/create-network-policies.sh
@@ -23,8 +23,8 @@ cf add-network-policy kibana es-proxy
 cf add-network-policy prometheus alertmanager
 cf add-network-policy prometheus cf-metrics
 cf add-network-policy prometheus cortex --protocol tcp --port 61443
-cf add-network-policy prometheus elasticsearch-metrics
 cf add-network-policy prometheus grafana --port 61443 --protocol tcp
+cf add-network-policy prometheus elasticsearch-metrics --protocol tcp --port 61443
 cf add-network-policy prometheus kong --port 8100 --protocol tcp
 cf add-network-policy prometheus redis-metrics
 cf add-network-policy prometheus watchtower --protocol tcp --port 61443

--- a/create-network-policies.sh
+++ b/create-network-policies.sh
@@ -26,5 +26,5 @@ cf add-network-policy prometheus cortex --protocol tcp --port 61443
 cf add-network-policy prometheus grafana --port 61443 --protocol tcp
 cf add-network-policy prometheus elasticsearch-metrics --protocol tcp --port 61443
 cf add-network-policy prometheus kong --port 8100 --protocol tcp
-cf add-network-policy prometheus redis-metrics
+cf add-network-policy prometheus redis-metrics --protocol tcp --port 61443
 cf add-network-policy prometheus watchtower --protocol tcp --port 61443

--- a/create-network-policies.sh
+++ b/create-network-policies.sh
@@ -27,4 +27,4 @@ cf add-network-policy prometheus elasticsearch-metrics
 cf add-network-policy prometheus grafana --port 61443 --protocol tcp
 cf add-network-policy prometheus kong --port 8100 --protocol tcp
 cf add-network-policy prometheus redis-metrics
-cf add-network-policy prometheus watchtower
+cf add-network-policy prometheus watchtower --protocol tcp --port 61443

--- a/create-network-policies.sh
+++ b/create-network-policies.sh
@@ -22,7 +22,7 @@ cf add-network-policy kibana es-proxy
 # Source = Prometheus
 cf add-network-policy prometheus alertmanager
 cf add-network-policy prometheus cf-metrics
-cf add-network-policy prometheus cortex
+cf add-network-policy prometheus cortex --protocol tcp --port 61443
 cf add-network-policy prometheus elasticsearch-metrics
 cf add-network-policy prometheus grafana --port 61443 --protocol tcp
 cf add-network-policy prometheus kong --port 8100 --protocol tcp

--- a/prometheus/prometheus-config.yml
+++ b/prometheus/prometheus-config.yml
@@ -65,8 +65,9 @@ scrape_configs:
       - targets: ['identity-idva-monitoring-grafana-${ENVIRONMENT_NAME}.apps.internal:61443']
 
   - job_name: 'watchtower'
+    scheme: https
     static_configs:
-      - targets: ['identity-idva-monitoring-watchtower-${ENVIRONMENT_NAME}.apps.internal:8080']
+      - targets: ['identity-idva-monitoring-watchtower-${ENVIRONMENT_NAME}.apps.internal:61443']
 
   - job_name: 'redis-exporter'
     scheme: https

--- a/prometheus/prometheus-config.yml
+++ b/prometheus/prometheus-config.yml
@@ -75,5 +75,6 @@ scrape_configs:
       - targets: ['identity-idva-metrics-redis-${ENVIRONMENT_NAME}.apps.internal:8080']
 
   - job_name: 'elasticsearch-exporter'
+    scheme: https
     static_configs:
-      - targets: ['identity-idva-metrics-elasticsearch-${ENVIRONMENT_NAME}.apps.internal:8080']
+      - targets: ['identity-idva-metrics-elasticsearch-${ENVIRONMENT_NAME}.apps.internal:61443']

--- a/prometheus/prometheus-config.yml
+++ b/prometheus/prometheus-config.yml
@@ -69,10 +69,8 @@ scrape_configs:
 
   - job_name: 'redis-exporter'
     scheme: https
-    tls_config:
-      insecure_skip_verify: true
     static_configs:
-      - targets: ['identity-idva-metrics-redis-${ENVIRONMENT_NAME}.apps.internal:8080']
+      - targets: ['identity-idva-metrics-redis-${ENVIRONMENT_NAME}.apps.internal:61443']
 
   - job_name: 'elasticsearch-exporter'
     scheme: https

--- a/prometheus/prometheus-config.yml
+++ b/prometheus/prometheus-config.yml
@@ -30,9 +30,7 @@ rule_files:
   - "rules.yml"
 
 remote_write:
-  - url: https://identity-idva-monitoring-cortex-${ENVIRONMENT_NAME}.apps.internal:8080/api/v1/push
-    tls_config:
-      insecure_skip_verify: true
+  - url: https://identity-idva-monitoring-cortex-${ENVIRONMENT_NAME}.apps.internal:61443/api/v1/push
 
 scrape_configs:
   # The job name is added as a label `job=<job_name>` to any timeseries scraped

--- a/redis/manifest.yaml
+++ b/redis/manifest.yaml
@@ -13,8 +13,6 @@ applications:
       ./redis_exporter --web.listen-address 0.0.0.0:8080 \
         --redis.addr "rediss://$( echo $VCAP_SERVICES | jq -r '."aws-elasticache-redis"[0].credentials.host')" \
         --redis.password $( echo $VCAP_SERVICES | jq -r '."aws-elasticache-redis"[0].credentials.password') \
-        --tls-server-key-file $CF_INSTANCE_KEY \
-        --tls-server-cert-file $CF_INSTANCE_CERT \
         --check-keys '*Connector'
     services:
       - sk-redis


### PR DESCRIPTION
- Switch to using https port for Watchtower
- Switch to using https port for Cortex
- Switch to using https port for ES exporter
- Switch to using https port for Redis exporter
