### PR TITLE
correct cortex datasource port

### DIFF
--- a/create-network-policies.sh
+++ b/create-network-policies.sh
@@ -13,7 +13,7 @@ cf add-network-policy alertmanager alertmanager --protocol udp --port 9094
 cf add-network-policy elasticsearch-metrics es-proxy
 
 # Source = Grafana
-cf add-network-policy grafana cortex
+cf add-network-policy grafana cortex --protocol tcp --port 61443
 cf add-network-policy grafana prometheus --protocol tcp --port 61443
 
 # Source = Kibana

--- a/grafana/conf/provisioning/datasources/cortex.yaml
+++ b/grafana/conf/provisioning/datasources/cortex.yaml
@@ -5,7 +5,7 @@ datasources:
   - name: idva-cortex-data
     type: prometheus
     access: proxy
-    url: https://identity-idva-monitoring-cortex-${ENVIRONMENT_NAME}.apps.internal:$PORT/api/prom/
+    url: https://identity-idva-monitoring-cortex-${ENVIRONMENT_NAME}.apps.internal:61443/api/prom/
     isDefault: false
     editable: false
     jsonData:


### PR DESCRIPTION
- Correct port used to contact the Cortex datasource
- Update Grafana->Cortex network policy
