### PR TITLE
Switch to cloud.gov https port for es-proxy

### DIFF
--- a/create-network-policies.sh
+++ b/create-network-policies.sh
@@ -10,14 +10,14 @@ cf add-network-policy alertmanager alertmanager --protocol tcp --port 9094
 cf add-network-policy alertmanager alertmanager --protocol udp --port 9094
 
 # Source = Elasticsearch-metrics
-cf add-network-policy elasticsearch-metrics es-proxy
+cf add-network-policy elasticsearch-metrics es-proxy --protocol tcp --port 61443
 
 # Source = Grafana
 cf add-network-policy grafana cortex --protocol tcp --port 61443
 cf add-network-policy grafana prometheus --protocol tcp --port 61443
 
 # Source = Kibana
-cf add-network-policy kibana es-proxy
+cf add-network-policy kibana es-proxy --protocol tcp --port 61443
 
 # Source = Prometheus
 cf add-network-policy prometheus alertmanager

--- a/elasticsearch/manifest.yaml
+++ b/elasticsearch/manifest.yaml
@@ -10,4 +10,4 @@ applications:
       - binary_buildpack
     command: |
       ./install_elasticsearch_exporter.sh && \
-      ./elasticsearch_exporter --es.uri http://identity-idva-es-proxy-((ENVIRONMENT_NAME)).apps.internal:8080 --web.listen-address :8080
+      ./elasticsearch_exporter --es.uri https://identity-idva-es-proxy-((ENVIRONMENT_NAME)).apps.internal:61443 --web.listen-address :8080

--- a/kibana/config/kibana.yml
+++ b/kibana/config/kibana.yml
@@ -29,7 +29,7 @@
 #server.name: "your-hostname"
 
 # The URLs of the Elasticsearch instances to use for all your queries.
-elasticsearch.hosts: ["http://identity-idva-es-proxy-${ENVIRONMENT_NAME}.apps.internal:8080"]
+elasticsearch.hosts: ["https://identity-idva-es-proxy-${ENVIRONMENT_NAME}.apps.internal:61443"]
 
 # Kibana uses an index in Elasticsearch to store saved searches, visualizations and
 # dashboards. Kibana creates a new index if the index doesn't already exist.


### PR DESCRIPTION
Both the Elasticsearch Prometheus exporter and the Kibana app within
IDVA use the es-proxy to support aws sigV4 signing. By switching to
connecting via https over 61443 we better protect all information
over those connections.
