### PR TITLE
Increase ES exporter timeout setting

### DIFF
--- a/elasticsearch/manifest.yaml
+++ b/elasticsearch/manifest.yaml
@@ -10,4 +10,4 @@ applications:
       - binary_buildpack
     command: |
       ./install_elasticsearch_exporter.sh && \
-      ./elasticsearch_exporter --es.uri https://identity-idva-es-proxy-((ENVIRONMENT_NAME)).apps.internal:61443 --web.listen-address :8080
+      ./elasticsearch_exporter --es.uri https://identity-idva-es-proxy-((ENVIRONMENT_NAME)).apps.internal:61443 --web.listen-address :8080 --es.timeout 20s


### PR DESCRIPTION
Over the period from March 11, 2022 10:00AM to March 18, 2022 10:00 AM
there were an average of 8.8 timeout errors per hour from the ES
exporter ("context deadline exceeded (Client.Timeout exceeded while
awaiting headers)".

By SSH'ing into the es exporter and performing curl requests to the same
endpoint as the exporter, we can see that the requests do take a few
seconds to execute, but they always seem to finish if given enough time.

By increasing the timeout settings for the exporter via the "es.timeout"
CLI flag, the average has dropped to ~1 per hour (based only on a couple
of hours worth of data, rather than a week). Estimated reduction of
timeout errors will be around 9-10X.
