### PR TITLE
Increase high memory alert threshold to 90%

### DIFF
--- a/prometheus/rules.yml
+++ b/prometheus/rules.yml
@@ -27,7 +27,7 @@ groups:
           icon: 🖥️
 
       - alert: High memory utilization
-        expr: avg by (app) (avg_over_time(memory_utilization[5m])) > 80
+        expr: avg by (app) (avg_over_time(memory_utilization[5m])) > 90
         annotations:
           summary: >-
             High memory usage ({{ $value | printf "%.2f"}}%) for


### PR DESCRIPTION
Over time, the IDVA system has seen hundreds, if not thousands of alerts
due to this threshold. Those alerts are almost never valuable. In the
majority of cases, an app has been steady-state usage just above the 80%
threshold, or sees cycles of higher and lower utilizations. For the
cases where memory usage has been a problem and caused crashes to apps,
it has almost always happened too quickly to be caught proactively by
this alert. Raising this threshold should aleviate the vast majority of
the false positives being triggered
