### PR TITLE
alertmanager use cloud gov certs

### DIFF
--- a/alertmanager/create_web_config.sh
+++ b/alertmanager/create_web_config.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-# See https://docs.cloudfoundry.org/devguide/deploy-apps/instance-identity.html
-# for information on Cloud Foundry Instance Identity Credentials.
-{
-    echo "---"
-    echo "tls_server_config:"
-    echo "  cert_file: $CF_INSTANCE_CERT"
-    echo "  key_file: $CF_INSTANCE_KEY"
-} > web-config.yml

--- a/alertmanager/manifest.yaml
+++ b/alertmanager/manifest.yaml
@@ -9,11 +9,9 @@ applications:
       - binary_buildpack
     command: |
       ./install_alertmanager.sh && \
-      ./create_web_config.sh && \
       ./alertmanager --web.listen-address="0.0.0.0:$PORT" \
-          --cluster.peer="identity-idva-monitoring-alertmanager-((ENVIRONMENT_NAME)).apps.internal:9094" \
-          --web.config.file=web-config.yml \
-          --web.external-url https://identity-idva-monitoring-alertmanager-((ENVIRONMENT_NAME)).apps.internal/
+          --cluster.peer="identity-idva-monitoring-alertmanager-((ENVIRONMENT_NAME)).apps.internal:9094"
+          --web.external-url http://identity-idva-monitoring-alertmanager-((ENVIRONMENT_NAME)).apps.internal/
     env:
       SLACK_URL: ((SLACK_URL))
       ENVIRONMENT_NAME: ((ENVIRONMENT_NAME))

--- a/alertmanager/manifest.yaml
+++ b/alertmanager/manifest.yaml
@@ -10,7 +10,7 @@ applications:
     command: |
       ./install_alertmanager.sh && \
       ./alertmanager --web.listen-address="0.0.0.0:$PORT" \
-          --cluster.peer="identity-idva-monitoring-alertmanager-((ENVIRONMENT_NAME)).apps.internal:9094"
+          --cluster.peer="identity-idva-monitoring-alertmanager-((ENVIRONMENT_NAME)).apps.internal:9094" \
           --web.external-url http://identity-idva-monitoring-alertmanager-((ENVIRONMENT_NAME)).apps.internal/
     env:
       SLACK_URL: ((SLACK_URL))

--- a/create-network-policies.sh
+++ b/create-network-policies.sh
@@ -13,18 +13,18 @@ cf add-network-policy alertmanager alertmanager --protocol udp --port 9094
 cf add-network-policy elasticsearch-metrics es-proxy --protocol tcp --port 61443
 
 # Source = Grafana
-cf add-network-policy grafana cortex --protocol tcp --port 61443
+cf add-network-policy grafana cortex     --protocol tcp --port 61443
 cf add-network-policy grafana prometheus --protocol tcp --port 61443
 
 # Source = Kibana
 cf add-network-policy kibana es-proxy --protocol tcp --port 61443
 
 # Source = Prometheus
-cf add-network-policy prometheus alertmanager
-cf add-network-policy prometheus cf-metrics --protocol tcp --port 61443
-cf add-network-policy prometheus cortex --protocol tcp --port 61443
-cf add-network-policy prometheus grafana --port 61443 --protocol tcp
+cf add-network-policy prometheus alertmanager          --protocol tcp --port 61443
+cf add-network-policy prometheus cf-metrics            --protocol tcp --port 61443
+cf add-network-policy prometheus cortex                --protocol tcp --port 61443
+cf add-network-policy prometheus grafana               --protocol tcp --port 61443 
 cf add-network-policy prometheus elasticsearch-metrics --protocol tcp --port 61443
-cf add-network-policy prometheus kong --port 8100 --protocol tcp
-cf add-network-policy prometheus redis-metrics --protocol tcp --port 61443
-cf add-network-policy prometheus watchtower --protocol tcp --port 61443
+cf add-network-policy prometheus kong                  --protocol tcp --port 8100
+cf add-network-policy prometheus redis-metrics         --protocol tcp --port 61443
+cf add-network-policy prometheus watchtower            --protocol tcp --port 61443

--- a/prometheus/prometheus-config.yml
+++ b/prometheus/prometheus-config.yml
@@ -15,14 +15,9 @@ alerting:
       regex: instance
 
   alertmanagers:
-    - dns_sd_configs:
-        - names:
-            - 'identity-idva-monitoring-alertmanager-${ENVIRONMENT_NAME}.apps.internal'
-          type: 'A'
-          port: 8080
-      tls_config:
-        insecure_skip_verify: true
-      scheme: https
+    - scheme: https
+      static_configs:
+        - targets: ['monitoring-alertmanager-${ENVIRONMENT_NAME}.apps.internal:61443']
 
 # Load rules once and periodically evaluate them according to the
 # global 'evaluation_interval'.


### PR DESCRIPTION
Configures traffic from Prometheus to Alertmanager to use the cloud.gov certificates
over 61443 that include the app SAN. This change also necessitated changing the
service discovery type for Alermanager to a static_config, since the SAN on the cloud.gov
cert does not include individual IP addresses (which is what Prometheus will use for
alerts instead of a DNS entry for dns_sd_configs).

- Configure Prometheus to use Cloud.gov https port
- Remove usage of instance identity certs for alertmanager
- Change prometheus -> alertmanager port in network policies