### PR TITLE
Fix url for Alertmanager that was altered during testing

### DIFF
--- a/prometheus/prometheus-config.yml
+++ b/prometheus/prometheus-config.yml
@@ -17,7 +17,7 @@ alerting:
   alertmanagers:
     - scheme: https
       static_configs:
-        - targets: ['monitoring-alertmanager-${ENVIRONMENT_NAME}.apps.internal:61443']
+        - targets: ['identity-idva-monitoring-alertmanager-${ENVIRONMENT_NAME}.apps.internal:61443']
 
 # Load rules once and periodically evaluate them according to the
 # global 'evaluation_interval'.


### PR DESCRIPTION
Correction of URL for Alertmanager that was modified during the testing process of #170 