### PR TITLE
Remove insecure_skip_verify configuration for cf-metrics scrape

### DIFF
--- a/prometheus/prometheus-config.yml
+++ b/prometheus/prometheus-config.yml
@@ -47,8 +47,6 @@ scrape_configs:
 
   - job_name: 'cf-metrics'
     scheme: https
-    tls_config:
-      insecure_skip_verify: true
     static_configs:
       - targets: ['identity-idva-cf-metrics-${ENVIRONMENT_NAME}.apps.internal:61443']
 


### PR DESCRIPTION
All the necessary certificates and network policies are already in place to perform full validation of this connection. Remove the old configuration specifying to skip validation.