### PR TITLE
watchtower use outbound proxy

### DIFF
--- a/.github/workflows/deploy-alertmanager.yaml
+++ b/.github/workflows/deploy-alertmanager.yaml
@@ -50,3 +50,5 @@ jobs:
 
       - name: Apply CF Network Policies
         run: ./create-network-policies.sh
+        env:
+          ENVIRONMENT_NAME: ${{ steps.cf-setup.outputs.target-environment }}

--- a/.github/workflows/deploy-cortex.yaml
+++ b/.github/workflows/deploy-cortex.yaml
@@ -36,3 +36,5 @@ jobs:
 
       - name: Apply CF Network Policies
         run: ./create-network-policies.sh
+        env:
+          ENVIRONMENT_NAME: ${{ steps.cf-setup.outputs.target-environment }}

--- a/.github/workflows/deploy-es.yaml
+++ b/.github/workflows/deploy-es.yaml
@@ -37,3 +37,5 @@ jobs:
 
       - name: Apply CF Network Policies
         run: ./create-network-policies.sh
+        env:
+          ENVIRONMENT_NAME: ${{ steps.cf-setup.outputs.target-environment }}

--- a/.github/workflows/deploy-grafana.yaml
+++ b/.github/workflows/deploy-grafana.yaml
@@ -41,3 +41,5 @@ jobs:
 
       - name: Apply CF Network Policies
         run: ./create-network-policies.sh
+        env:
+          ENVIRONMENT_NAME: ${{ steps.cf-setup.outputs.target-environment }}

--- a/.github/workflows/deploy-kibana.yaml
+++ b/.github/workflows/deploy-kibana.yaml
@@ -36,3 +36,5 @@ jobs:
 
       - name: Apply CF Network Policies
         run: ./create-network-policies.sh
+        env:
+          ENVIRONMENT_NAME: ${{ steps.cf-setup.outputs.target-environment }}

--- a/.github/workflows/deploy-prometheus.yaml
+++ b/.github/workflows/deploy-prometheus.yaml
@@ -44,3 +44,5 @@ jobs:
 
       - name: Apply CF Network Policies
         run: ./create-network-policies.sh
+        env:
+          ENVIRONMENT_NAME: ${{ steps.cf-setup.outputs.target-environment }}

--- a/.github/workflows/deploy-watchtower.yaml
+++ b/.github/workflows/deploy-watchtower.yaml
@@ -27,12 +27,17 @@ jobs:
           cf-username: ${{ secrets.CF_USERNAME }}
           cf-password: ${{ secrets.CF_PASSWORD }}
           cf-org: ${{ secrets.CF_ORG }}
+          space-suffix: "-closed"
 
       - name: Set audit user credentials
         run: |
           target_env_upper=${{ steps.cf-setup.outputs.target-environment-upper }}
           echo "watchtower_user=WATCHTOWER_USER_$target_env_upper" >> $GITHUB_ENV
           echo "watchtower_pass=WATCHTOWER_PASS_$target_env_upper" >> $GITHUB_ENV
+
+      - name: Install Watchtower
+        run: ./install_watchtower.sh
+        working-directory: ./watchtower
 
       - name: Deploy Watchtower
         run: cf push --vars-file vars.yaml

--- a/create-network-policies.sh
+++ b/create-network-policies.sh
@@ -5,26 +5,44 @@
 # create the required network policies instead of adding custom "run"
 # scripts within the action.
 
+if [ -z "$ENVIRONMENT_NAME" ]; then
+  echo "No ENVIRONMENT_NAME variable found."
+  exit 1
+fi
+
+
+# The base environment (dev|test|prod) will have the restricted-egress policies attached.
+# See: https://cloud.gov/docs/management/space-egress/#restricted-egress
+restricted="$ENVIRONMENT_NAME"
+public="$restricted-public"
+closed="$restricted-closed"
+
+cf target -s "$restricted"
+
 # Source = Alertmanager
-cf add-network-policy alertmanager alertmanager --protocol tcp --port 9094
-cf add-network-policy alertmanager alertmanager --protocol udp --port 9094
+cf add-network-policy alertmanager alertmanager --protocol tcp --port 9094 -s "$restricted"
+cf add-network-policy alertmanager alertmanager --protocol udp --port 9094 -s "$restricted"
 
 # Source = Elasticsearch-metrics
-cf add-network-policy elasticsearch-metrics es-proxy --protocol tcp --port 61443
+cf add-network-policy elasticsearch-metrics es-proxy --protocol tcp --port 61443 -s "$restricted"
 
 # Source = Grafana
-cf add-network-policy grafana cortex     --protocol tcp --port 61443
-cf add-network-policy grafana prometheus --protocol tcp --port 61443
+cf add-network-policy grafana cortex     --protocol tcp --port 61443 -s "$restricted"
+cf add-network-policy grafana prometheus --protocol tcp --port 61443 -s "$restricted"
 
 # Source = Kibana
 cf add-network-policy kibana es-proxy --protocol tcp --port 61443
 
 # Source = Prometheus
-cf add-network-policy prometheus alertmanager          --protocol tcp --port 61443
-cf add-network-policy prometheus cf-metrics            --protocol tcp --port 61443
-cf add-network-policy prometheus cortex                --protocol tcp --port 61443
-cf add-network-policy prometheus grafana               --protocol tcp --port 61443 
-cf add-network-policy prometheus elasticsearch-metrics --protocol tcp --port 61443
-cf add-network-policy prometheus kong                  --protocol tcp --port 8100
-cf add-network-policy prometheus redis-metrics         --protocol tcp --port 61443
-cf add-network-policy prometheus watchtower            --protocol tcp --port 61443
+cf add-network-policy prometheus alertmanager          --protocol tcp --port 61443 -s "$restricted"
+cf add-network-policy prometheus cf-metrics            --protocol tcp --port 61443 -s "$restricted"
+cf add-network-policy prometheus cortex                --protocol tcp --port 61443 -s "$restricted"
+cf add-network-policy prometheus grafana               --protocol tcp --port 61443 -s "$restricted"
+cf add-network-policy prometheus elasticsearch-metrics --protocol tcp --port 61443 -s "$restricted"
+cf add-network-policy prometheus kong                  --protocol tcp --port 8100  -s "$restricted"
+cf add-network-policy prometheus redis-metrics         --protocol tcp --port 61443 -s "$restricted"
+cf add-network-policy prometheus watchtower            --protocol tcp --port 61443 -s "$closed"
+
+cf target -s "$closed"
+
+cf add-network-policy watchtower outbound-proxy        --protocol tcp --port 61443 -s "$public"

--- a/watchtower/.profile
+++ b/watchtower/.profile
@@ -1,8 +1,12 @@
 #!/bin/bash
-proxy_url=$(echo "$VCAP_SERVICES" | jq '.["user-provided"][] | select(.name == "outbound-proxy") | .credentials.proxy_url')
+proxy_url=$(echo "$VCAP_SERVICES" | jq -r '."user-provided"?[]? | select(.name == "outbound-proxy") | .credentials.proxy_url')
 
 # Export the proxy variables if the "proxy_url" variable is not empty
 if [ -n "$proxy_url" ]; then
-  export HTTP_PROXY=$proxy_url
-  export HTTPS_PROXY=$proxy_url
+  export HTTP_PROXY="$proxy_url"
+  export HTTPS_PROXY="$proxy_url"
+  echo ".profile script automatically set HTTP_PROXY: $HTTP_PROXY"
+  echo ".profile script automatically set HTTPS_PROXY: $HTTPS_PROXY"
+else
+  echo ".profile script did not find proxy information in VCAP_SERVICES"
 fi

--- a/watchtower/manifest.yaml
+++ b/watchtower/manifest.yaml
@@ -9,6 +9,8 @@ applications:
     health-check-http-endpoint: /health
     buildpacks:
       - binary_buildpack
+    services:
+      - outbound-proxy
     command: |
       ./install_watchtower.sh && \
       ./watchtower

--- a/watchtower/manifest.yaml
+++ b/watchtower/manifest.yaml
@@ -11,9 +11,7 @@ applications:
       - binary_buildpack
     services:
       - outbound-proxy
-    command: |
-      ./install_watchtower.sh && \
-      ./watchtower
+    command: ./watchtower
     env:
       ENVIRONMENT_NAME: ((ENVIRONMENT_NAME))
       CF_USER: ((CF_USER))


### PR DESCRIPTION
- Improve .profile proxy initialization
- Add environment_name variable to network policy setup
- Add outbound-proxy to service bindings
- Move Watchtower installation outside of Cloud.gov
- Add multi-space support to network policy creation
