### PR TITLE
Enable TLS for Alertmanger gossip traffic

### DIFF
--- a/alertmanager/create_tls_config.sh
+++ b/alertmanager/create_tls_config.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# See https://docs.cloudfoundry.org/devguide/deploy-apps/instance-identity.html
+# for information on Cloud Foundry Instance Identity Credentials.
+{
+  echo "---"
+  echo "tls_server_config:"
+  echo "  cert_file: $CF_INSTANCE_CERT"
+  echo "  key_file: $CF_INSTANCE_KEY"
+  echo "tls_client_config:"
+  echo "  ca_file: /etc/cf-system-certificates/trusted-ca-1.crt"
+} > tls-config.yml

--- a/alertmanager/manifest.yaml
+++ b/alertmanager/manifest.yaml
@@ -9,8 +9,10 @@ applications:
       - binary_buildpack
     command: |
       ./install_alertmanager.sh && \
+      ./create_tls_config.sh && \
       ./alertmanager --web.listen-address="0.0.0.0:$PORT" \
           --cluster.peer="identity-idva-monitoring-alertmanager-((ENVIRONMENT_NAME)).apps.internal:9094" \
+          --cluster.tls-config=tls-config.yml \
           --web.external-url http://identity-idva-monitoring-alertmanager-((ENVIRONMENT_NAME)).apps.internal/
     env:
       SLACK_URL: ((SLACK_URL))


### PR DESCRIPTION
Version 0.24.0 of Alertmanager now provides (albeit experimental)
support for TLS with the cluster gossip traffic. We can start taking
advantage of this feature by creating the TLS config and populating it
with the CF Instance Identity certs that are available on the
application instnces since these certs will contain the app IP SAN. See
https://docs.cloudfoundry.org/devguide/deploy-apps/instance-identity.html
