### PR TITLE
restrict egress

### DIFF
--- a/.github/workflows/deploy-alertmanager.yaml
+++ b/.github/workflows/deploy-alertmanager.yaml
@@ -31,6 +31,11 @@ jobs:
           cf-username: ${{ secrets.CF_USERNAME }}
           cf-password: ${{ secrets.CF_PASSWORD }}
           cf-org: ${{ secrets.CF_ORG }}
+          space-suffix: "-public"
+
+      - name: Install Alertmanager
+        run: ./install_alertmanager.sh
+        working-directory: ./alertmanager
 
       - name: Generate config files
         run: |

--- a/.github/workflows/deploy-cortex.yaml
+++ b/.github/workflows/deploy-cortex.yaml
@@ -28,6 +28,10 @@ jobs:
           cf-password: ${{ secrets.CF_PASSWORD }}
           cf-org: ${{ secrets.CF_ORG }}
 
+      - name: Install Cortex
+        run: ./install_cortex.sh
+        working-directory: ./cortex
+
       - name: Deploy Cortex
         run: cf push --vars-file vars.yaml
           --var ENVIRONMENT_NAME=${{ steps.cf-setup.outputs.target-environment }}

--- a/.github/workflows/deploy-es.yaml
+++ b/.github/workflows/deploy-es.yaml
@@ -27,6 +27,11 @@ jobs:
           cf-username: ${{ secrets.CF_USERNAME }}
           cf-password: ${{ secrets.CF_PASSWORD }}
           cf-org: ${{ secrets.CF_ORG }}
+          space-suffix: "-closed"
+
+      - name: Install ElasticSearch Exporter
+        run: ./install_elasticsearch_exporter.sh
+        working-directory: ./elasticsearch
 
       - name: Deploy Elasticsearch Exporter
         run: cf push

--- a/.github/workflows/deploy-grafana.yaml
+++ b/.github/workflows/deploy-grafana.yaml
@@ -27,6 +27,7 @@ jobs:
           cf-username: ${{ secrets.CF_USERNAME }}
           cf-password: ${{ secrets.CF_PASSWORD }}
           cf-org: ${{ secrets.CF_ORG }}
+          space-suffix: "-closed"
 
       - name: Install Grafana
         run: ./install_grafana.sh

--- a/.github/workflows/deploy-prometheus.yaml
+++ b/.github/workflows/deploy-prometheus.yaml
@@ -31,6 +31,7 @@ jobs:
           cf-username: ${{ secrets.CF_USERNAME }}
           cf-password: ${{ secrets.CF_PASSWORD }}
           cf-org: ${{ secrets.CF_ORG }}
+          space-suffix: "-closed"
 
       - name: Install Prometheus
         run: ./install_prometheus.sh

--- a/alertmanager/manifest.yaml
+++ b/alertmanager/manifest.yaml
@@ -8,7 +8,6 @@ applications:
     buildpacks:
       - binary_buildpack
     command: |
-      ./install_alertmanager.sh && \
       ./create_tls_config.sh && \
       ./alertmanager --web.listen-address="0.0.0.0:$PORT" \
           --cluster.peer="identity-idva-monitoring-alertmanager-((ENVIRONMENT_NAME)).apps.internal:9094" \

--- a/cortex/manifest.yaml
+++ b/cortex/manifest.yaml
@@ -10,7 +10,6 @@ applications:
     services:
       - prometheus-storage
     command: |
-      ./install_cortex.sh
       export BUCKET_NAME=$(echo $VCAP_SERVICES | jq '.s3[0].credentials.bucket')
       export BUCKET_ENDPOINT=$(echo $VCAP_SERVICES | jq '.s3[0].credentials.fips_endpoint')
       export AWS_REGION=$(echo $VCAP_SERVICES | jq '.s3[0].credentials.region')

--- a/create-network-policies.sh
+++ b/create-network-policies.sh
@@ -20,15 +20,15 @@ closed="$restricted-closed"
 cf target -s "$restricted"
 
 # Source = Kibana
-cf add-network-policy kibana es-proxy --protocol tcp --port 61443
+cf add-network-policy kibana es-proxy                  --protocol tcp --port 61443 -s "$restricted"
 
 cf target -s "$closed"
 
 cf add-network-policy watchtower outbound-proxy        --protocol tcp --port 61443 -s "$public"
 
 # Source = Grafana
-cf add-network-policy grafana cortex     --protocol tcp --port 61443 -s "$restricted"
-cf add-network-policy grafana prometheus --protocol tcp --port 61443 -s "$closed"
+cf add-network-policy grafana cortex                   --protocol tcp --port 61443 -s "$restricted"
+cf add-network-policy grafana prometheus               --protocol tcp --port 61443 -s "$closed"
 
 # Source = Prometheus
 cf add-network-policy prometheus alertmanager          --protocol tcp --port 61443 -s "$public"
@@ -41,10 +41,10 @@ cf add-network-policy prometheus redis-metrics         --protocol tcp --port 614
 cf add-network-policy prometheus watchtower            --protocol tcp --port 61443 -s "$closed"
 
 # Source = Elasticsearch-metrics
-cf add-network-policy elasticsearch-metrics es-proxy --protocol tcp --port 61443 -s "$restricted"
+cf add-network-policy elasticsearch-metrics es-proxy   --protocol tcp --port 61443 -s "$restricted"
 
 cf target -s "$public"
 
 # Source = Alertmanager
-cf add-network-policy alertmanager alertmanager --protocol tcp --port 9094 -s "$public"
-cf add-network-policy alertmanager alertmanager --protocol udp --port 9094 -s "$public"
+cf add-network-policy alertmanager alertmanager        --protocol tcp --port 9094 -s "$public"
+cf add-network-policy alertmanager alertmanager        --protocol udp --port 9094 -s "$public"

--- a/create-network-policies.sh
+++ b/create-network-policies.sh
@@ -20,8 +20,8 @@ closed="$restricted-closed"
 cf target -s "$restricted"
 
 # Source = Alertmanager
-cf add-network-policy alertmanager alertmanager --protocol tcp --port 9094 -s "$restricted"
-cf add-network-policy alertmanager alertmanager --protocol udp --port 9094 -s "$restricted"
+cf add-network-policy alertmanager alertmanager --protocol tcp --port 9094 -s "$public"
+cf add-network-policy alertmanager alertmanager --protocol udp --port 9094 -s "$public"
 
 # Source = Elasticsearch-metrics
 cf add-network-policy elasticsearch-metrics es-proxy --protocol tcp --port 61443 -s "$restricted"
@@ -34,7 +34,7 @@ cf add-network-policy grafana prometheus --protocol tcp --port 61443 -s "$restri
 cf add-network-policy kibana es-proxy --protocol tcp --port 61443
 
 # Source = Prometheus
-cf add-network-policy prometheus alertmanager          --protocol tcp --port 61443 -s "$restricted"
+cf add-network-policy prometheus alertmanager          --protocol tcp --port 61443 -s "$public"
 cf add-network-policy prometheus cf-metrics            --protocol tcp --port 61443 -s "$restricted"
 cf add-network-policy prometheus cortex                --protocol tcp --port 61443 -s "$restricted"
 cf add-network-policy prometheus grafana               --protocol tcp --port 61443 -s "$restricted"

--- a/create-network-policies.sh
+++ b/create-network-policies.sh
@@ -19,9 +19,6 @@ closed="$restricted-closed"
 
 cf target -s "$restricted"
 
-# Source = Elasticsearch-metrics
-cf add-network-policy elasticsearch-metrics es-proxy --protocol tcp --port 61443 -s "$restricted"
-
 # Source = Kibana
 cf add-network-policy kibana es-proxy --protocol tcp --port 61443
 
@@ -38,10 +35,13 @@ cf add-network-policy prometheus alertmanager          --protocol tcp --port 614
 cf add-network-policy prometheus cf-metrics            --protocol tcp --port 61443 -s "$restricted"
 cf add-network-policy prometheus cortex                --protocol tcp --port 61443 -s "$restricted"
 cf add-network-policy prometheus grafana               --protocol tcp --port 61443 -s "$closed"
-cf add-network-policy prometheus elasticsearch-metrics --protocol tcp --port 61443 -s "$restricted"
+cf add-network-policy prometheus elasticsearch-metrics --protocol tcp --port 61443 -s "$closed"
 cf add-network-policy prometheus kong                  --protocol tcp --port 8100  -s "$closed"
 cf add-network-policy prometheus redis-metrics         --protocol tcp --port 61443 -s "$restricted"
 cf add-network-policy prometheus watchtower            --protocol tcp --port 61443 -s "$closed"
+
+# Source = Elasticsearch-metrics
+cf add-network-policy elasticsearch-metrics es-proxy --protocol tcp --port 61443 -s "$restricted"
 
 cf target -s "$public"
 

--- a/create-network-policies.sh
+++ b/create-network-policies.sh
@@ -19,16 +19,8 @@ closed="$restricted-closed"
 
 cf target -s "$restricted"
 
-# Source = Alertmanager
-cf add-network-policy alertmanager alertmanager --protocol tcp --port 9094 -s "$public"
-cf add-network-policy alertmanager alertmanager --protocol udp --port 9094 -s "$public"
-
 # Source = Elasticsearch-metrics
 cf add-network-policy elasticsearch-metrics es-proxy --protocol tcp --port 61443 -s "$restricted"
-
-# Source = Grafana
-cf add-network-policy grafana cortex     --protocol tcp --port 61443 -s "$restricted"
-cf add-network-policy grafana prometheus --protocol tcp --port 61443 -s "$restricted"
 
 # Source = Kibana
 cf add-network-policy kibana es-proxy --protocol tcp --port 61443
@@ -37,7 +29,7 @@ cf add-network-policy kibana es-proxy --protocol tcp --port 61443
 cf add-network-policy prometheus alertmanager          --protocol tcp --port 61443 -s "$public"
 cf add-network-policy prometheus cf-metrics            --protocol tcp --port 61443 -s "$restricted"
 cf add-network-policy prometheus cortex                --protocol tcp --port 61443 -s "$restricted"
-cf add-network-policy prometheus grafana               --protocol tcp --port 61443 -s "$restricted"
+cf add-network-policy prometheus grafana               --protocol tcp --port 61443 -s "$closed"
 cf add-network-policy prometheus elasticsearch-metrics --protocol tcp --port 61443 -s "$restricted"
 cf add-network-policy prometheus kong                  --protocol tcp --port 8100  -s "$closed"
 cf add-network-policy prometheus redis-metrics         --protocol tcp --port 61443 -s "$restricted"
@@ -46,3 +38,13 @@ cf add-network-policy prometheus watchtower            --protocol tcp --port 614
 cf target -s "$closed"
 
 cf add-network-policy watchtower outbound-proxy        --protocol tcp --port 61443 -s "$public"
+
+# Source = Grafana
+cf add-network-policy grafana cortex     --protocol tcp --port 61443 -s "$restricted"
+cf add-network-policy grafana prometheus --protocol tcp --port 61443 -s "$restricted"
+
+cf target -s "$public"
+
+# Source = Alertmanager
+cf add-network-policy alertmanager alertmanager --protocol tcp --port 9094 -s "$public"
+cf add-network-policy alertmanager alertmanager --protocol udp --port 9094 -s "$public"

--- a/create-network-policies.sh
+++ b/create-network-policies.sh
@@ -25,6 +25,14 @@ cf add-network-policy elasticsearch-metrics es-proxy --protocol tcp --port 61443
 # Source = Kibana
 cf add-network-policy kibana es-proxy --protocol tcp --port 61443
 
+cf target -s "$closed"
+
+cf add-network-policy watchtower outbound-proxy        --protocol tcp --port 61443 -s "$public"
+
+# Source = Grafana
+cf add-network-policy grafana cortex     --protocol tcp --port 61443 -s "$restricted"
+cf add-network-policy grafana prometheus --protocol tcp --port 61443 -s "$closed"
+
 # Source = Prometheus
 cf add-network-policy prometheus alertmanager          --protocol tcp --port 61443 -s "$public"
 cf add-network-policy prometheus cf-metrics            --protocol tcp --port 61443 -s "$restricted"
@@ -34,14 +42,6 @@ cf add-network-policy prometheus elasticsearch-metrics --protocol tcp --port 614
 cf add-network-policy prometheus kong                  --protocol tcp --port 8100  -s "$closed"
 cf add-network-policy prometheus redis-metrics         --protocol tcp --port 61443 -s "$restricted"
 cf add-network-policy prometheus watchtower            --protocol tcp --port 61443 -s "$closed"
-
-cf target -s "$closed"
-
-cf add-network-policy watchtower outbound-proxy        --protocol tcp --port 61443 -s "$public"
-
-# Source = Grafana
-cf add-network-policy grafana cortex     --protocol tcp --port 61443 -s "$restricted"
-cf add-network-policy grafana prometheus --protocol tcp --port 61443 -s "$restricted"
 
 cf target -s "$public"
 

--- a/elasticsearch/manifest.yaml
+++ b/elasticsearch/manifest.yaml
@@ -8,6 +8,4 @@ applications:
       - route: identity-idva-metrics-elasticsearch-((ENVIRONMENT_NAME)).apps.internal
     buildpacks:
       - binary_buildpack
-    command: |
-      ./install_elasticsearch_exporter.sh && \
-      ./elasticsearch_exporter --es.uri https://identity-idva-es-proxy-((ENVIRONMENT_NAME)).apps.internal:61443 --web.listen-address :8080 --es.timeout 20s
+    command: ./elasticsearch_exporter --es.uri https://identity-idva-es-proxy-((ENVIRONMENT_NAME)).apps.internal:61443 --web.listen-address :8080 --es.timeout 20s

--- a/kibana/manifest.yaml
+++ b/kibana/manifest.yaml
@@ -8,8 +8,7 @@ applications:
     buildpacks:
       - https://github.com/cloudfoundry/apt-buildpack
       - binary_buildpack
-    command: |
-      /home/vcap/deps/0/apt/usr/share/kibana/bin/kibana --config config/kibana.yml
+    command: /home/vcap/deps/0/apt/usr/share/kibana/bin/kibana --config config/kibana.yml
     routes:
       - route: identity-idva-monitoring-kibana-((ENVIRONMENT_NAME)).apps.internal
     env:


### PR DESCRIPTION
- Move alertmanager to public egress space
- Move Cortex install into GitHub Action
- Move Grafana to a closed-egress space type
- Move Prometheus to closed-egress space type
- Move ElasticSearch exporter to closed-egress space type
- Simplify kibana manifest.yaml
- Add spacing to improve network policy script readability
