### PR TITLE
Upload additional data to pass rate document

### DIFF
--- a/idvametrics/main.py
+++ b/idvametrics/main.py
@@ -17,7 +17,12 @@ METRIC_DEFINITIONS = {
         "index_pattern": EVENTS_INDEX_PATTERN,
         "metric": "connector_pass_rate",
         "metric_keys": ["flowId", "interactionId", "id", "tsEms"],
-        "document_keys": ["id", "connectionId", {"property": "outcomeStatus"}],
+        "document_keys": [
+            "id",
+            "connectionId",
+            {"property": "outcomeStatus"},
+            {"property": "outcomeType"},
+        ],
     },
     "connector_response_time": {
         "index_pattern": SK_INDEX_PATTERN,


### PR DESCRIPTION
Currently, we do not have the necessary data in the analytics index to differentiate where a user is in a flow when they reach a point of verification. That information is contained in the `outcomeType` property, which needs to be written into analytics documents for use in Kibana.