### PR TITLE
Valid import of submodule

### DIFF
--- a/idvametrics/analyticsquery.py
+++ b/idvametrics/analyticsquery.py
@@ -6,7 +6,7 @@ against a server and uploading to an index.
 import datetime
 import hashlib
 import typing
-import dateutil
+import dateutil.parser
 import opensearchpy
 import analyticsutils
 

--- a/idvametrics/analyticsutils.py
+++ b/idvametrics/analyticsutils.py
@@ -4,7 +4,7 @@ Provides utility functions for use in analytics scripting.
 
 import sys
 import datetime
-import dateutil
+import dateutil.parser
 import requests
 import login
 


### PR DESCRIPTION
The `dateutil` parser submodule cannot be accessed through `dateutil.parser` if we only do `import dateutil`. This PR fixes errors related to the submodule importing and accessing.