### PR TITLE
Move Cortex to public space for S3 access

### DIFF
--- a/.github/workflows/deploy-cortex.yaml
+++ b/.github/workflows/deploy-cortex.yaml
@@ -27,6 +27,7 @@ jobs:
           cf-username: ${{ secrets.CF_USERNAME }}
           cf-password: ${{ secrets.CF_PASSWORD }}
           cf-org: ${{ secrets.CF_ORG }}
+          space-suffix: "-public"
 
       - name: Install Cortex
         run: ./install_cortex.sh

--- a/create-network-policies.sh
+++ b/create-network-policies.sh
@@ -30,13 +30,13 @@ cf target -s "$closed"
 cf add-network-policy watchtower outbound-proxy        --protocol tcp --port 61443 -s "$public"
 
 # Source = Grafana
-cf add-network-policy grafana cortex                   --protocol tcp --port 61443 -s "$restricted"
+cf add-network-policy grafana cortex                   --protocol tcp --port 61443 -s "$public"
 cf add-network-policy grafana prometheus               --protocol tcp --port 61443 -s "$closed"
 
 # Source = Prometheus
 cf add-network-policy prometheus alertmanager          --protocol tcp --port 61443 -s "$public"
 cf add-network-policy prometheus cf-metrics            --protocol tcp --port 61443 -s "$restricted"
-cf add-network-policy prometheus cortex                --protocol tcp --port 61443 -s "$restricted"
+cf add-network-policy prometheus cortex                --protocol tcp --port 61443 -s "$public"
 cf add-network-policy prometheus grafana               --protocol tcp --port 61443 -s "$closed"
 cf add-network-policy prometheus elasticsearch-metrics --protocol tcp --port 61443 -s "$closed"
 cf add-network-policy prometheus kong                  --protocol tcp --port 8100  -s "$closed"


### PR DESCRIPTION
Because Cortex is unable to access S3 due to space egress control limitations, we are moving it to a public-egress space.