### PR TITLE
Remove basic auth

### DIFF
--- a/grafana/conf/custom.ini
+++ b/grafana/conf/custom.ini
@@ -5,5 +5,6 @@ domain = identity-idva-monitoring-grafana-${ENVIRONMENT_NAME}.apps.internal
 root_url = %(protocol)s://%(domain)s:%(http_port)s/grafana/
 serve_from_sub_path = true
 
-[security]
-admin_password = ${GRAFANA_PASS}
+[auth.anonymous]
+enabled = true
+org_role = Admin


### PR DESCRIPTION
The IDVA team has never made its Grafana instance publicly accessible,
and the use of basic auth was simply because it was there. The Grafana
application is already protected by the standard GSA authentication
mechanisms and requires MFA. We are removing basic auth as it
contributes little to the overall security posture of the service and
reduces the number of secrets required for the IVDA team to manage.
